### PR TITLE
feat: login screen and editable work schedule config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
 NODE_ENV=development
 CACHE_DISABLED=true
 
-# ControlIT Credentials
-CONTROLIT_USERNAME=your_username_here
-CONTROLIT_PASSWORD=your_password_here
+# Session secret (required in production — use a long random string)
+SESSION_SECRET=change-me-in-production
+
+# ControlIT Credentials (optional — can be entered via login screen instead)
+CONTROLIT_USERNAME=
+CONTROLIT_PASSWORD=
 
 # Server Configuration
 PORT=3009

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage/
 .nyc_output/
 backups/
 logs/
+data/
 
 # API explorer output — may contain captured credentials/tokens
 docs/api-captured.json

--- a/logic.js
+++ b/logic.js
@@ -5,18 +5,11 @@ import FormData from 'form-data';
 import * as cheerio from 'cheerio';
 import { get, set, cacheKeys } from './utils/cache.js';
 import { logInfo, logWarn } from './utils/logger.js';
+import { getScheduleConfig } from './utils/scheduleConfig.js';
 
-const currentYear = DateTime.now().year;
-const summerStart = DateTime.fromObject({
-  day: config.summerStartDay,
-  month: config.summerStartMonth,
-  year: currentYear
-});
-const summerEnd = DateTime.fromObject({
-  day: config.summerEndDay,
-  month: config.summerEndMonth,
-  year: currentYear
-});
+function getCreds(credentials) {
+  return credentials || { username: config.username, password: config.password };
+}
 
 function formatDate(date) {
   return date.toFormat("yyyy-MM-dd'T'HH':'mm':'ssZZ");
@@ -35,6 +28,11 @@ async function login(username, password) {
 
   const data = await response.json();
   return data.User.AccessToken;
+}
+
+// Exported for use by auth route to validate credentials
+export async function loginUser(username, password) {
+  return login(username, password);
 }
 
 function buildHeaders(token) {
@@ -126,7 +124,7 @@ async function fetchLeaveDays(token) {
 
 // ─── Time-off map (combines calendar + leave days)
 
-export async function getTimeOffDaysDetailed() {
+export async function getTimeOffDaysDetailed(credentials) {
   const cacheKey = cacheKeys.vacationDaysDetailed();
   const cached = get(cacheKey);
   if (cached) {
@@ -135,7 +133,8 @@ export async function getTimeOffDaysDetailed() {
   }
 
   logInfo('Fetching time-off days from API');
-  const token = await login(config.username, config.password);
+  const creds = getCreds(credentials);
+  const token = await login(creds.username, creds.password);
 
   const [calendarMap, { map: leaveMap }] = await Promise.all([
     fetchCalendarDays(token, DateTime.now().year),
@@ -152,7 +151,7 @@ export async function getTimeOffDaysDetailed() {
 
 // ─── Leave days list (for the UI panel)
 
-export async function getLeaveDaysList() {
+export async function getLeaveDaysList(credentials) {
   const cacheKey = cacheKeys.leaveDays();
   const cached = get(cacheKey);
   if (cached) {
@@ -161,7 +160,8 @@ export async function getLeaveDaysList() {
   }
 
   logInfo('Fetching leave days list from API');
-  const token = await login(config.username, config.password);
+  const creds = getCreds(credentials);
+  const token = await login(creds.username, creds.password);
   const { list } = await fetchLeaveDays(token);
 
   // Sort by start date ascending, keep only relevant fields
@@ -183,8 +183,9 @@ export async function getLeaveDaysList() {
 
 // ─── Disable (undo) a registered day
 
-export async function disableDay(date) {
-  const token = await login(config.username, config.password);
+export async function disableDay(date, credentials) {
+  const creds = getCreds(credentials);
+  const token = await login(creds.username, creds.password);
   const formattedDate = DateTime.fromISO(date).toFormat('dd-MM-yyyy');
 
   // Fetch events registered for this day
@@ -240,13 +241,26 @@ export async function disableDay(date) {
 
 // ─── Submit hours range
 
-export async function submitHoursRange({ startDate, endDate, dryRun = true }) {
+export async function submitHoursRange({ startDate, endDate, dryRun = true, credentials }) {
+  const scheduleConfig = getScheduleConfig();
+  const currentYear = DateTime.now().year;
+  const summerStart = DateTime.fromObject({
+    day:   scheduleConfig.summerStartDay,
+    month: scheduleConfig.summerStartMonth,
+    year:  currentYear,
+  });
+  const summerEnd = DateTime.fromObject({
+    day:   scheduleConfig.summerEndDay,
+    month: scheduleConfig.summerEndMonth,
+    year:  currentYear,
+  });
+
   const start = DateTime.fromISO(startDate);
   const end = DateTime.fromISO(endDate);
   const days = [];
   let cursor = start;
 
-  const timeOffMap = await getTimeOffDaysDetailed();
+  const timeOffMap = await getTimeOffDaysDetailed(credentials);
 
   while (cursor <= end) {
     const isoDate = cursor.toISODate();
@@ -264,7 +278,8 @@ export async function submitHoursRange({ startDate, endDate, dryRun = true }) {
 
   let accessToken = null;
   if (!dryRun) {
-    accessToken = await login(config.username, config.password);
+    const creds = getCreds(credentials);
+    accessToken = await login(creds.username, creds.password);
   }
 
   const results = [];
@@ -277,16 +292,16 @@ export async function submitHoursRange({ startDate, endDate, dryRun = true }) {
     let workStartRaw, workEnd, lunchStart, lunchEnd;
 
     if (isShortDay) {
-      const t = config.workSchedule.summer.start;
+      const t = scheduleConfig.workSchedule.summer.start;
       workStartRaw = day.set({ hour: t.hour, minute: t.minute + randomJitter() });
-      workEnd = workStartRaw.plus(config.workSchedule.summer.length);
+      workEnd = workStartRaw.plus(scheduleConfig.workSchedule.summer.length);
     } else {
-      const t = config.workSchedule.winter.start;
-      const lunch = config.workSchedule.lunch.start;
+      const t = scheduleConfig.workSchedule.winter.start;
+      const lunch = scheduleConfig.workSchedule.lunch.start;
       workStartRaw = day.set({ hour: t.hour, minute: t.minute + randomJitter() });
-      workEnd = workStartRaw.plus(config.workSchedule.winter.length).plus(config.workSchedule.lunch.length);
+      workEnd = workStartRaw.plus(scheduleConfig.workSchedule.winter.length).plus(scheduleConfig.workSchedule.lunch.length);
       lunchStart = day.set({ hour: lunch.hour, minute: lunch.minute + randomJitter() });
-      lunchEnd = lunchStart.plus(config.workSchedule.lunch.length);
+      lunchEnd = lunchStart.plus(scheduleConfig.workSchedule.lunch.length);
     }
 
     const workStart = formatDate(workStartRaw);
@@ -316,10 +331,10 @@ function randomJitter() {
   return Math.round(Math.random() * config.jitterMinutes);
 }
 
-export async function getRegisteredDays(startDate, endDate) {
+export async function getRegisteredDays(startDate, endDate, credentials) {
   const [timeOffMap, registeredFromReport] = await Promise.all([
-    getTimeOffDaysDetailed(),
-    getRegisteredDaysFromReport(startDate, endDate)
+    getTimeOffDaysDetailed(credentials),
+    getRegisteredDaysFromReport(startDate, endDate, credentials)
   ]);
   const start = DateTime.fromISO(startDate);
   const end = DateTime.fromISO(endDate);
@@ -344,11 +359,12 @@ export async function getRegisteredDays(startDate, endDate) {
   return calendarData;
 }
 
-export async function getDetailedEventsByRange(startDate, endDate) {
-  const registeredDays = await getRegisteredDaysFromReport(startDate, endDate);
+export async function getDetailedEventsByRange(startDate, endDate, credentials) {
+  const registeredDays = await getRegisteredDaysFromReport(startDate, endDate, credentials);
   const results = [];
 
-  const token = await login(config.username, config.password);
+  const creds = getCreds(credentials);
+  const token = await login(creds.username, creds.password);
 
   for (const date of registeredDays) {
     const formattedDate = DateTime.fromISO(date).toFormat('dd-MM-yyyy');
@@ -370,13 +386,13 @@ export async function getDetailedEventsByRange(startDate, endDate) {
   return results;
 }
 
-export async function getVacationDays() {
+export async function getVacationDays(credentials) {
   // Backward compatibility: return array of all time-off days
-  const detailed = await getTimeOffDaysDetailed();
+  const detailed = await getTimeOffDaysDetailed(credentials);
   return Object.keys(detailed);
 }
 
-export async function getRegisteredDaysFromReport(startDate, endDate) {
+export async function getRegisteredDaysFromReport(startDate, endDate, credentials) {
   const cacheKey = cacheKeys.registeredDays(startDate, endDate);
 
   const cachedData = get(cacheKey);
@@ -386,7 +402,8 @@ export async function getRegisteredDaysFromReport(startDate, endDate) {
   }
 
   logInfo('Fetching registered days from API', { startDate, endDate });
-  const token = await login(config.username, config.password);
+  const creds = getCreds(credentials);
+  const token = await login(creds.username, creds.password);
   const formData = new FormData();
   formData.append('startDate', DateTime.fromISO(startDate).toFormat('dd-MM-yyyy'));
   formData.append('endDate', DateTime.fromISO(endDate).toFormat('dd-MM-yyyy'));

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,9 @@
+export function requireAuth(req, res, next) {
+  if (req.session && req.session.credentials) {
+    return next();
+  }
+  if (req.xhr || req.headers.accept?.includes('application/json') || req.headers['content-type']?.includes('application/json')) {
+    return res.status(401).json({ success: false, error: 'No autenticado' });
+  }
+  return res.redirect('/login');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-rate-limit": "^8.1.0",
+        "express-session": "^1.19.0",
         "form-data": "^4.0.2",
         "luxon": "^3.6.1",
         "node-cache": "^5.1.2",
@@ -2374,6 +2375,50 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "~5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4316,6 +4361,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4720,6 +4774,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -5481,6 +5544,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-rate-limit": "^8.1.0",
+    "express-session": "^1.19.0",
     "form-data": "^4.0.2",
     "luxon": "^3.6.1",
     "node-cache": "^5.1.2",

--- a/public/app.css
+++ b/public/app.css
@@ -321,7 +321,8 @@ body {
 }
 
 .form-group input[type="date"],
-.form-group input[type="text"] {
+.form-group input[type="text"],
+.form-group input[type="password"] {
   width: 100%;
   padding: 0.75rem 1rem;
   border: 2px solid var(--gray-300);
@@ -332,7 +333,8 @@ body {
 }
 
 .form-group input[type="date"]:focus,
-.form-group input[type="text"]:focus {
+.form-group input[type="text"]:focus,
+.form-group input[type="password"]:focus {
   outline: none;
   border-color: var(--primary-color);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
@@ -985,6 +987,33 @@ form.validated .form-group input[type="date"]:invalid {
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+}
+
+/* ─── Current user badge ───────────────────────────────────────────── */
+
+.current-user {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--gray-600);
+  background: var(--gray-100);
+  border: 1px solid var(--gray-200);
+  border-radius: 2rem;
+  padding: 0.35rem 0.75rem;
+  max-width: 180px;
+}
+
+.current-user i {
+  color: var(--primary-color);
+  flex-shrink: 0;
+}
+
+.current-user__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ─── Settings Modal ───────────────────────────────────────────────── */

--- a/public/app.css
+++ b/public/app.css
@@ -977,3 +977,156 @@ form.validated .form-group input[type="date"]:invalid {
 .calendar-day.registered:hover {
   filter: brightness(0.88);
 }
+
+/* ─── Header Actions ───────────────────────────────────────────────── */
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* ─── Settings Modal ───────────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  backdrop-filter: blur(2px);
+}
+
+.modal-overlay[hidden] { display: none; }
+
+.modal-container {
+  background: white;
+  border-radius: var(--border-radius-lg);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--gray-200);
+  flex-shrink: 0;
+}
+
+.modal-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.modal-header h2 i {
+  color: var(--primary-color);
+}
+
+.modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--gray-200);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.modal-footer-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.settings-section {
+  margin-bottom: 1.5rem;
+}
+
+.settings-section:last-child {
+  margin-bottom: 0;
+}
+
+.settings-section h3 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--gray-500);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.settings-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.settings-row .form-group {
+  flex: 1;
+  min-width: 140px;
+  margin-bottom: 0;
+}
+
+.settings-row .form-group label {
+  font-size: 0.8rem;
+  margin-bottom: 0.4rem;
+  color: var(--gray-600);
+}
+
+.time-inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.time-inputs span {
+  color: var(--gray-500);
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.input-narrow {
+  width: 3.5rem;
+  padding: 0.5rem 0.4rem;
+  border: 2px solid var(--gray-300);
+  border-radius: var(--border-radius);
+  font-size: 0.9rem;
+  text-align: center;
+  background: white;
+  transition: border-color 0.15s;
+}
+
+.input-narrow:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+/* ─── Number input arrows hide ─────────────────────────────────────── */
+.input-narrow::-webkit-inner-spin-button,
+.input-narrow::-webkit-outer-spin-button {
+  opacity: 1;
+}

--- a/public/app.js
+++ b/public/app.js
@@ -318,4 +318,165 @@ document.addEventListener('DOMContentLoaded', async function () {
       if (next >= 0 && next < days.length) days[next].focus();
     }
   });
+
+  // --- 401 redirect helper ---
+
+  function guardedFetch(url, options) {
+    return fetch(url, options).then(res => {
+      if (res.status === 401) { window.location.href = '/login'; }
+      return res;
+    });
+  }
+
+  // Patch existing fetch calls to use guardedFetch — replace references on calendarContainer
+  // and undoConfirmBtn by overriding window.fetch for internal calls.
+  // (Simpler: just patch window.fetch for same-origin calls)
+  const _origFetch = window.fetch;
+  window.fetch = function (input, init) {
+    const url = typeof input === 'string' ? input : input?.url;
+    if (url && !url.startsWith('http')) {
+      return _origFetch(input, init).then(res => {
+        if (res.status === 401) { window.location.href = '/login'; }
+        return res;
+      });
+    }
+    return _origFetch(input, init);
+  };
+
+  // --- Settings modal ---
+
+  const settingsBtn      = document.getElementById('settings-btn');
+  const settingsOverlay  = document.getElementById('settings-overlay');
+  const settingsCloseBtn = document.getElementById('settings-close-btn');
+  const settingsCancelBtn= document.getElementById('settings-cancel-btn');
+  const settingsSaveBtn  = document.getElementById('settings-save-btn');
+  const settingsResetBtn = document.getElementById('settings-reset-btn');
+  const settingsAlert    = document.getElementById('settings-alert');
+
+  function showSettingsAlert(msg, type = 'error') {
+    if (!settingsAlert) return;
+    settingsAlert.innerHTML = `<div class="alert alert-${type}" style="margin-bottom:1rem;"><i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'}"></i><div>${msg}</div></div>`;
+    setTimeout(() => { settingsAlert.innerHTML = ''; }, 4000);
+  }
+
+  function populateForm(cfg) {
+    const s = id => document.getElementById(id);
+    s('s-winter-start-hour').value    = cfg.workSchedule.winter.start.hour;
+    s('s-winter-start-minute').value  = cfg.workSchedule.winter.start.minute;
+    s('s-winter-length-hours').value  = cfg.workSchedule.winter.length.hours;
+    s('s-winter-length-minutes').value= cfg.workSchedule.winter.length.minutes;
+    s('s-lunch-start-hour').value     = cfg.workSchedule.lunch.start.hour;
+    s('s-lunch-start-minute').value   = cfg.workSchedule.lunch.start.minute;
+    s('s-lunch-length-hours').value   = cfg.workSchedule.lunch.length.hours;
+    s('s-lunch-length-minutes').value = cfg.workSchedule.lunch.length.minutes;
+    s('s-summer-start-hour').value    = cfg.workSchedule.summer.start.hour;
+    s('s-summer-start-minute').value  = cfg.workSchedule.summer.start.minute;
+    s('s-summer-length-hours').value  = cfg.workSchedule.summer.length.hours;
+    s('s-summer-length-minutes').value= cfg.workSchedule.summer.length.minutes;
+    s('s-summer-start-day').value     = cfg.summerStartDay;
+    s('s-summer-start-month').value   = cfg.summerStartMonth;
+    s('s-summer-end-day').value       = cfg.summerEndDay;
+    s('s-summer-end-month').value     = cfg.summerEndMonth;
+  }
+
+  function collectForm() {
+    const g = id => parseInt(document.getElementById(id).value, 10);
+    return {
+      workSchedule: {
+        winter: {
+          start:  { hour: g('s-winter-start-hour'),  minute: g('s-winter-start-minute') },
+          length: { hours: g('s-winter-length-hours'), minutes: g('s-winter-length-minutes') },
+        },
+        lunch: {
+          start:  { hour: g('s-lunch-start-hour'),   minute: g('s-lunch-start-minute') },
+          length: { hours: g('s-lunch-length-hours'),  minutes: g('s-lunch-length-minutes') },
+        },
+        summer: {
+          start:  { hour: g('s-summer-start-hour'),  minute: g('s-summer-start-minute') },
+          length: { hours: g('s-summer-length-hours'), minutes: g('s-summer-length-minutes') },
+        },
+      },
+      summerStartDay:   g('s-summer-start-day'),
+      summerStartMonth: g('s-summer-start-month'),
+      summerEndDay:     g('s-summer-end-day'),
+      summerEndMonth:   g('s-summer-end-month'),
+    };
+  }
+
+  async function openSettings() {
+    if (!settingsOverlay) return;
+    settingsOverlay.hidden = false;
+    try {
+      const res = await fetch('/api/schedule-config');
+      const json = await res.json();
+      if (json.success) populateForm(json.config);
+    } catch {
+      showSettingsAlert('No se pudo cargar la configuración');
+    }
+  }
+
+  function closeSettings() {
+    if (settingsOverlay) settingsOverlay.hidden = true;
+    if (settingsAlert) settingsAlert.innerHTML = '';
+  }
+
+  if (settingsBtn)       settingsBtn.addEventListener('click', openSettings);
+  if (settingsCloseBtn)  settingsCloseBtn.addEventListener('click', closeSettings);
+  if (settingsCancelBtn) settingsCancelBtn.addEventListener('click', closeSettings);
+
+  if (settingsOverlay) {
+    settingsOverlay.addEventListener('click', function (e) {
+      if (e.target === settingsOverlay) closeSettings();
+    });
+  }
+
+  if (settingsSaveBtn) {
+    settingsSaveBtn.addEventListener('click', async function () {
+      settingsSaveBtn.disabled = true;
+      try {
+        const body = collectForm();
+        const res = await fetch('/api/schedule-config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (json.success) {
+          showSettingsAlert('Configuración guardada correctamente', 'success');
+          setTimeout(closeSettings, 1200);
+        } else {
+          showSettingsAlert(json.error || 'Error al guardar');
+        }
+      } catch {
+        showSettingsAlert('Error al guardar la configuración');
+      } finally {
+        settingsSaveBtn.disabled = false;
+      }
+    });
+  }
+
+  if (settingsResetBtn) {
+    settingsResetBtn.addEventListener('click', async function () {
+      if (!confirm('¿Restaurar los valores por defecto del .env?')) return;
+      settingsResetBtn.disabled = true;
+      try {
+        const res = await fetch('/api/schedule-config', { method: 'DELETE' });
+        const json = await res.json();
+        if (json.success) {
+          populateForm(json.config);
+          showSettingsAlert('Valores restaurados a los valores por defecto', 'success');
+        }
+      } catch {
+        showSettingsAlert('Error al restaurar la configuración');
+      } finally {
+        settingsResetBtn.disabled = false;
+      }
+    });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && settingsOverlay && !settingsOverlay.hidden) {
+      closeSettings();
+    }
+  });
 });

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authLimiter } from '../middleware/rateLimiter.js';
+import { loginUser } from '../logic.js';
+
+export default function createAuthRouter() {
+  const router = Router();
+
+  router.get('/login', (req, res) => {
+    if (req.session?.credentials) return res.redirect('/');
+    res.render('login', { error: null });
+  });
+
+  router.post('/login', authLimiter, async (req, res) => {
+    const { username, password } = req.body;
+
+    if (!username || !password) {
+      return res.render('login', { error: 'Usuario y contraseña son obligatorios' });
+    }
+
+    try {
+      await loginUser(username, password);
+      req.session.credentials = { username, password };
+      return res.redirect('/');
+    } catch {
+      return res.render('login', { error: 'Credenciales incorrectas. Por favor, inténtalo de nuevo.' });
+    }
+  });
+
+  router.post('/logout', (req, res) => {
+    req.session.destroy(() => {
+      res.redirect('/login');
+    });
+  });
+
+  return router;
+}

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -101,6 +101,7 @@ export default function createCalendarRouter() {
       dryRun,
       stats,
       firstPending,
+      currentUser: credentials?.username ?? '',
     });
   }));
 

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -50,9 +50,10 @@ export default function createCalendarRouter() {
     const startISO = startDate.toISOString().slice(0, 10);
     const endISO = today.toISOString().slice(0, 10);
 
+    const credentials = req.session.credentials;
     const [registered, leaveDays] = await Promise.all([
-      getRegisteredDays(startISO, endISO),
-      getLeaveDaysList(),
+      getRegisteredDays(startISO, endISO, credentials),
+      getLeaveDaysList(credentials),
     ]);
 
     const calendarData = buildCalendarData(registered, startDate, today);
@@ -108,7 +109,7 @@ export default function createCalendarRouter() {
     const { startISO, endISO } = req.validatedDates;
     const isDryRunActive = dryRun === 'on';
 
-    const results = await submitHoursRange({ startDate: startISO, endDate: endISO, dryRun: isDryRunActive });
+    const results = await submitHoursRange({ startDate: startISO, endDate: endISO, dryRun: isDryRunActive, credentials: req.session.credentials });
 
     const today = new Date();
     const yearStart = new Date(today.getFullYear(), 0, 1);
@@ -131,7 +132,7 @@ export default function createCalendarRouter() {
     const { startISO, endISO } = req.validatedDates;
     const isDryRun = dryRun === 'on';
 
-    const results = await submitHoursRange({ startDate: startISO, endDate: endISO, dryRun: isDryRun });
+    const results = await submitHoursRange({ startDate: startISO, endDate: endISO, dryRun: isDryRun, credentials: req.session.credentials });
 
     try {
       const today = new Date();
@@ -151,7 +152,7 @@ export default function createCalendarRouter() {
       return res.status(400).json({ success: false, error: 'Fecha inválida' });
     }
 
-    const result = await disableDay(date);
+    const result = await disableDay(date, req.session.credentials);
 
     // Invalidate registered days cache so the calendar refreshes
     try {

--- a/routes/health.js
+++ b/routes/health.js
@@ -22,7 +22,7 @@ router.get('/health/live', (req, res) => {
 router.get('/health/ready', async (req, res) => {
   try {
     const config = await import('../config.js');
-    if (config.default.username && config.default.password) {
+    if (config.default.apiBaseUrl) {
       res.status(200).json({
         status: 'ready',
         timestamp: new Date().toISOString(),

--- a/routes/schedule.js
+++ b/routes/schedule.js
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { getScheduleConfig, updateScheduleConfig, resetScheduleConfig } from '../utils/scheduleConfig.js';
+
+function validateInt(val, min, max) {
+  const n = parseInt(val, 10);
+  return Number.isInteger(n) && n >= min && n <= max ? n : null;
+}
+
+export default function createScheduleRouter() {
+  const router = Router();
+
+  router.get('/api/schedule-config', requireAuth, (req, res) => {
+    res.json({ success: true, config: getScheduleConfig() });
+  });
+
+  router.put('/api/schedule-config', requireAuth, (req, res) => {
+    const b = req.body;
+
+    const fields = {
+      'workSchedule.winter.start.hour':    [b?.workSchedule?.winter?.start?.hour,    0, 23],
+      'workSchedule.winter.start.minute':  [b?.workSchedule?.winter?.start?.minute,  0, 59],
+      'workSchedule.winter.length.hours':  [b?.workSchedule?.winter?.length?.hours,  0, 23],
+      'workSchedule.winter.length.minutes':[b?.workSchedule?.winter?.length?.minutes, 0, 59],
+      'workSchedule.lunch.start.hour':     [b?.workSchedule?.lunch?.start?.hour,     0, 23],
+      'workSchedule.lunch.start.minute':   [b?.workSchedule?.lunch?.start?.minute,   0, 59],
+      'workSchedule.lunch.length.hours':   [b?.workSchedule?.lunch?.length?.hours,   0, 23],
+      'workSchedule.lunch.length.minutes': [b?.workSchedule?.lunch?.length?.minutes,  0, 59],
+      'workSchedule.summer.start.hour':    [b?.workSchedule?.summer?.start?.hour,    0, 23],
+      'workSchedule.summer.start.minute':  [b?.workSchedule?.summer?.start?.minute,  0, 59],
+      'workSchedule.summer.length.hours':  [b?.workSchedule?.summer?.length?.hours,  0, 23],
+      'workSchedule.summer.length.minutes':[b?.workSchedule?.summer?.length?.minutes, 0, 59],
+      'summerStartDay':   [b?.summerStartDay,   1, 31],
+      'summerStartMonth': [b?.summerStartMonth, 1, 12],
+      'summerEndDay':     [b?.summerEndDay,     1, 31],
+      'summerEndMonth':   [b?.summerEndMonth,   1, 12],
+    };
+
+    for (const [key, [val, min, max]] of Object.entries(fields)) {
+      if (validateInt(val, min, max) === null) {
+        return res.status(400).json({ success: false, error: `Campo inválido: ${key} (debe ser entero entre ${min} y ${max})` });
+      }
+    }
+
+    const newConfig = {
+      workSchedule: {
+        winter: {
+          start:  { hour: parseInt(b.workSchedule.winter.start.hour), minute: parseInt(b.workSchedule.winter.start.minute) },
+          length: { hours: parseInt(b.workSchedule.winter.length.hours), minutes: parseInt(b.workSchedule.winter.length.minutes) },
+        },
+        lunch: {
+          start:  { hour: parseInt(b.workSchedule.lunch.start.hour), minute: parseInt(b.workSchedule.lunch.start.minute) },
+          length: { hours: parseInt(b.workSchedule.lunch.length.hours), minutes: parseInt(b.workSchedule.lunch.length.minutes) },
+        },
+        summer: {
+          start:  { hour: parseInt(b.workSchedule.summer.start.hour), minute: parseInt(b.workSchedule.summer.start.minute) },
+          length: { hours: parseInt(b.workSchedule.summer.length.hours), minutes: parseInt(b.workSchedule.summer.length.minutes) },
+        },
+      },
+      summerStartDay:   parseInt(b.summerStartDay),
+      summerStartMonth: parseInt(b.summerStartMonth),
+      summerEndDay:     parseInt(b.summerEndDay),
+      summerEndMonth:   parseInt(b.summerEndMonth),
+    };
+
+    const saved = updateScheduleConfig(newConfig);
+    res.json({ success: true, config: saved });
+  });
+
+  router.delete('/api/schedule-config', requireAuth, (req, res) => {
+    const defaults = resetScheduleConfig();
+    res.json({ success: true, config: defaults });
+  });
+
+  return router;
+}

--- a/server.js
+++ b/server.js
@@ -3,9 +3,11 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import bodyParser from 'body-parser';
+import session from 'express-session';
 import fs from 'fs';
 import https from 'https';
 import { errorHandler, notFound } from './middleware/errorHandler.js';
+import { requireAuth } from './middleware/auth.js';
 import { logRequest } from './utils/logger.js';
 import { apiLimiter, submitLimiter } from './middleware/rateLimiter.js';
 import { metricsMiddleware } from './utils/metrics.js';
@@ -13,6 +15,8 @@ import { scheduleBackups } from './utils/backup.js';
 import healthRouter from './routes/health.js';
 import cacheRouter from './routes/cache.js';
 import createCalendarRouter from './routes/calendar.js';
+import createAuthRouter from './routes/auth.js';
+import createScheduleRouter from './routes/schedule.js';
 
 const app = express();
 
@@ -23,6 +27,18 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'controlJIJI-dev-secret',
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    secure: process.env.USE_HTTPS === 'true',
+    httpOnly: true,
+    maxAge: 24 * 60 * 60 * 1000,
+  },
+}));
 
 // Favicon handler — serves a 1x1 transparent PNG to avoid 404s
 app.get('/favicon.ico', (req, res) => {
@@ -38,11 +54,15 @@ app.use(logRequest);
 app.use('/submit', submitLimiter);
 app.use(apiLimiter);
 
-// Routes
+// Public routes (no auth required)
+app.use(createAuthRouter());
 app.use(healthRouter);
 app.use(cacheRouter);
 
+// Protected routes
+app.use(requireAuth);
 app.use(createCalendarRouter());
+app.use(createScheduleRouter());
 
 // Error handling (must be after routes)
 app.use(notFound);

--- a/utils/scheduleConfig.js
+++ b/utils/scheduleConfig.js
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import config from '../config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const CONFIG_FILE = path.join(DATA_DIR, 'schedule-config.json');
+
+function ensureDataDir() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function readOverrides() {
+  try {
+    ensureDataDir();
+    if (fs.existsSync(CONFIG_FILE)) {
+      return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+    }
+  } catch {}
+  return {};
+}
+
+function writeOverrides(overrides) {
+  ensureDataDir();
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(overrides, null, 2), 'utf8');
+}
+
+export function getScheduleConfig() {
+  const o = readOverrides();
+  return {
+    workSchedule: {
+      winter: {
+        start: {
+          hour:    o?.workSchedule?.winter?.start?.hour    ?? config.workSchedule.winter.start.hour,
+          minute:  o?.workSchedule?.winter?.start?.minute  ?? config.workSchedule.winter.start.minute,
+        },
+        length: {
+          hours:   o?.workSchedule?.winter?.length?.hours   ?? config.workSchedule.winter.length.hours,
+          minutes: o?.workSchedule?.winter?.length?.minutes ?? config.workSchedule.winter.length.minutes,
+        },
+      },
+      lunch: {
+        start: {
+          hour:    o?.workSchedule?.lunch?.start?.hour    ?? config.workSchedule.lunch.start.hour,
+          minute:  o?.workSchedule?.lunch?.start?.minute  ?? config.workSchedule.lunch.start.minute,
+        },
+        length: {
+          hours:   o?.workSchedule?.lunch?.length?.hours   ?? config.workSchedule.lunch.length.hours,
+          minutes: o?.workSchedule?.lunch?.length?.minutes ?? config.workSchedule.lunch.length.minutes,
+        },
+      },
+      summer: {
+        start: {
+          hour:    o?.workSchedule?.summer?.start?.hour    ?? config.workSchedule.summer.start.hour,
+          minute:  o?.workSchedule?.summer?.start?.minute  ?? config.workSchedule.summer.start.minute,
+        },
+        length: {
+          hours:   o?.workSchedule?.summer?.length?.hours   ?? config.workSchedule.summer.length.hours,
+          minutes: o?.workSchedule?.summer?.length?.minutes ?? config.workSchedule.summer.length.minutes,
+        },
+      },
+    },
+    summerStartDay:   o?.summerStartDay   ?? config.summerStartDay,
+    summerStartMonth: o?.summerStartMonth ?? config.summerStartMonth,
+    summerEndDay:     o?.summerEndDay     ?? config.summerEndDay,
+    summerEndMonth:   o?.summerEndMonth   ?? config.summerEndMonth,
+  };
+}
+
+export function updateScheduleConfig(newConfig) {
+  writeOverrides(newConfig);
+  return getScheduleConfig();
+}
+
+export function resetScheduleConfig() {
+  try {
+    if (fs.existsSync(CONFIG_FILE)) {
+      fs.unlinkSync(CONFIG_FILE);
+    }
+  } catch {}
+  return getScheduleConfig();
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,6 +37,12 @@
           <button type="button" id="settings-btn" class="btn btn-ghost btn-sm" aria-label="Configuración de horario" title="Configuración de horario">
             <i class="fas fa-cog"></i>
           </button>
+          <% if (typeof currentUser !== 'undefined' && currentUser) { %>
+          <span class="current-user" title="<%= currentUser %>">
+            <i class="fas fa-user-circle"></i>
+            <span class="current-user__name"><%= currentUser %></span>
+          </span>
+          <% } %>
           <form method="POST" action="/logout" style="display:inline;">
             <button type="submit" class="btn btn-ghost btn-sm" aria-label="Cerrar sesión" title="Cerrar sesión">
               <i class="fas fa-sign-out-alt"></i>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -19,22 +19,150 @@
           <h1><i class="fas fa-clock"></i> ControlIT - Registro de Horas</h1>
           <p>Automatiza el registro de tus horas laborales de forma eficiente y segura</p>
         </div>
-        <div class="simulation-toggle">
-          <span class="simulation-toggle__label">
-            <i class="fas fa-bolt"></i> Simulación
-          </span>
-          <button
-            type="button"
-            id="simulation-toggle-btn"
-            class="toggle-switch <%= dryRun ? 'toggle-switch--active' : '' %>"
-            aria-pressed="<%= dryRun %>"
-            aria-label="Modo simulación"
-          >
-            <span class="toggle-switch__thumb"></span>
+        <div class="header-actions">
+          <div class="simulation-toggle">
+            <span class="simulation-toggle__label">
+              <i class="fas fa-bolt"></i> Simulación
+            </span>
+            <button
+              type="button"
+              id="simulation-toggle-btn"
+              class="toggle-switch <%= dryRun ? 'toggle-switch--active' : '' %>"
+              aria-pressed="<%= dryRun %>"
+              aria-label="Modo simulación"
+            >
+              <span class="toggle-switch__thumb"></span>
+            </button>
+          </div>
+          <button type="button" id="settings-btn" class="btn btn-ghost btn-sm" aria-label="Configuración de horario" title="Configuración de horario">
+            <i class="fas fa-cog"></i>
           </button>
+          <form method="POST" action="/logout" style="display:inline;">
+            <button type="submit" class="btn btn-ghost btn-sm" aria-label="Cerrar sesión" title="Cerrar sesión">
+              <i class="fas fa-sign-out-alt"></i>
+            </button>
+          </form>
         </div>
       </div>
     </header>
+
+    <!-- Settings Modal -->
+    <div id="settings-overlay" class="modal-overlay" hidden aria-modal="true" role="dialog" aria-labelledby="settings-title">
+      <div class="modal-container">
+        <div class="modal-header">
+          <h2 id="settings-title"><i class="fas fa-cog"></i> Configuración de Horario</h2>
+          <button type="button" id="settings-close-btn" class="btn btn-ghost btn-sm" aria-label="Cerrar">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div id="settings-alert"></div>
+          <form id="settings-form">
+            <div class="settings-section">
+              <h3><i class="fas fa-sun"></i> Horario de Invierno (días normales)</h3>
+              <div class="settings-row">
+                <div class="form-group">
+                  <label>Entrada</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-winter-start-hour" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>:</span>
+                    <input type="number" id="s-winter-start-minute" min="0" max="59" class="input-narrow" placeholder="MM">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>Duración</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-winter-length-hours" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>h</span>
+                    <input type="number" id="s-winter-length-minutes" min="0" max="59" class="input-narrow" placeholder="MM">
+                    <span>m</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <h3><i class="fas fa-utensils"></i> Comida</h3>
+              <div class="settings-row">
+                <div class="form-group">
+                  <label>Inicio</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-lunch-start-hour" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>:</span>
+                    <input type="number" id="s-lunch-start-minute" min="0" max="59" class="input-narrow" placeholder="MM">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>Duración</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-lunch-length-hours" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>h</span>
+                    <input type="number" id="s-lunch-length-minutes" min="0" max="59" class="input-narrow" placeholder="MM">
+                    <span>m</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <h3><i class="fas fa-umbrella-beach"></i> Horario de Verano (viernes y periodo estival)</h3>
+              <div class="settings-row">
+                <div class="form-group">
+                  <label>Entrada</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-summer-start-hour" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>:</span>
+                    <input type="number" id="s-summer-start-minute" min="0" max="59" class="input-narrow" placeholder="MM">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>Duración</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-summer-length-hours" min="0" max="23" class="input-narrow" placeholder="HH">
+                    <span>h</span>
+                    <input type="number" id="s-summer-length-minutes" min="0" max="59" class="input-narrow" placeholder="MM">
+                    <span>m</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <h3><i class="fas fa-calendar-alt"></i> Periodo Estival</h3>
+              <div class="settings-row">
+                <div class="form-group">
+                  <label>Inicio (día/mes)</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-summer-start-day" min="1" max="31" class="input-narrow" placeholder="DD">
+                    <span>/</span>
+                    <input type="number" id="s-summer-start-month" min="1" max="12" class="input-narrow" placeholder="MM">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>Fin (día/mes)</label>
+                  <div class="time-inputs">
+                    <input type="number" id="s-summer-end-day" min="1" max="31" class="input-narrow" placeholder="DD">
+                    <span>/</span>
+                    <input type="number" id="s-summer-end-month" min="1" max="12" class="input-narrow" placeholder="MM">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" id="settings-reset-btn" class="btn btn-ghost btn-sm">
+            <i class="fas fa-undo"></i> Restaurar valores por defecto
+          </button>
+          <div class="modal-footer-actions">
+            <button type="button" id="settings-cancel-btn" class="btn btn-ghost">Cancelar</button>
+            <button type="button" id="settings-save-btn" class="btn btn-primary">
+              <i class="fas fa-save"></i> Guardar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- Loading Overlay -->
     <div id="loading-overlay" class="loading-overlay" style="display: none;">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ControlIT - Iniciar sesión</title>
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/app.css">
+  <style>
+    .login-wrapper {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .login-card {
+      width: 100%;
+      max-width: 420px;
+    }
+    .login-brand {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .login-brand h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      background: linear-gradient(135deg, var(--primary-color), var(--primary-dark));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 0.25rem;
+    }
+    .login-brand p {
+      color: var(--gray-500);
+      font-size: 0.9rem;
+    }
+    .login-submit {
+      width: 100%;
+      justify-content: center;
+      margin-top: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-wrapper">
+    <div class="login-card">
+      <div class="login-brand">
+        <h1><i class="fas fa-clock"></i> ControlIT</h1>
+        <p>Registro de Horas</p>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <i class="fas fa-sign-in-alt"></i>
+          <h2>Iniciar sesión</h2>
+        </div>
+
+        <% if (error) { %>
+        <div class="alert alert-error" style="margin-bottom: 1.25rem;">
+          <i class="fas fa-exclamation-circle"></i>
+          <div><%= error %></div>
+        </div>
+        <% } %>
+
+        <form method="POST" action="/login">
+          <div class="form-group">
+            <label for="username">
+              <i class="fas fa-user"></i> Usuario
+            </label>
+            <input
+              type="text"
+              id="username"
+              name="username"
+              required
+              autocomplete="username"
+              placeholder="tu@email.com"
+            >
+          </div>
+
+          <div class="form-group">
+            <label for="password">
+              <i class="fas fa-lock"></i> Contraseña
+            </label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              required
+              autocomplete="current-password"
+              placeholder="••••••••"
+            >
+          </div>
+
+          <button type="submit" class="btn btn-primary login-submit">
+            <i class="fas fa-sign-in-alt"></i> Entrar
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Login screen**: credentials are validated against the ControlIT API and stored in the session — no longer needed in `.env`. All app routes are protected; health endpoints remain public.
- **Editable work schedule**: settings modal (gear icon in header) to edit winter/summer hours, lunch break, and summer period dates. Overrides saved to `data/schedule-config.json` (gitignored), merged over `.env` defaults at runtime.
- **UI fixes**: password input full-width styling, logged-in username shown as a pill badge in the header.

## Test plan

- [ ] Navigate to `/` without a session → redirects to `/login`
- [ ] Login with valid ControlIT credentials → redirects to calendar, username shown in header
- [ ] Login with wrong credentials → error message shown, stays on login page
- [ ] Click logout → returns to `/login`
- [ ] `/health` and `/health/ready` accessible without login
- [ ] Click gear icon → settings modal opens with current schedule values
- [ ] Edit a value and save → `data/schedule-config.json` is created with the override
- [ ] Register a day → uses the updated schedule values
- [ ] Click "Restore defaults" → overrides file deleted, form repopulates with `.env` defaults
- [ ] Password input matches the username input size on the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)