### PR TITLE
fix: handle cancelled state for vacation requests and leave days

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -109,8 +109,8 @@ async function fetchLeaveDays(token) {
 
   for (const leave of leaveDays) {
     if (!leave.Start || !leave.End) continue;
-    // State 1 = pending, State 3 = approved
-    // Use date-only strings to avoid timezone shifts (e.g. Railway running in UTC)
+    // State 1 = pending, State 2 = cancelled, State 3 = approved
+    if (leave.State === 2) continue;
     const startStr = leave.Start.split('T')[0];
     const endStr   = leave.End.split('T')[0];
     const status   = leave.State === 3 ? 'leave' : 'leave-pending';
@@ -147,8 +147,9 @@ async function fetchVacationData(token) {
 
     if (entry.IsHoliday) {
       map[iso] = 'holiday';
-    } else if (entry.DayType === 1) {
+    } else if (entry.DayType === 1 && entry.State !== 2) {
       // Vacation: State 3 = approved, State 1 = pending/requested
+      // State 2 = cancelled (skip — treat as regular workday)
       if (!map[iso] || map[iso] !== 'holiday') {
         map[iso] = entry.State === 3 ? 'vacation' : 'vacation-pending';
       }
@@ -233,7 +234,7 @@ export async function getVacationRequestsList(credentials) {
 
   const result = ranges.map(r => ({
     type: 'Vacaciones',
-    state: r.state === 3 ? 'Aprobada' : 'Solicitada',
+    state: r.state === 3 ? 'Aprobada' : r.state === 2 ? 'Cancelada' : 'Solicitada',
     stateCode: r.state,
     start: r.start,
     end: r.end,

--- a/logic.js
+++ b/logic.js
@@ -241,6 +241,8 @@ export async function getVacationRequestsList(credentials) {
     year: r.year,
   }));
 
+  logInfo('Vacation ranges from API', { count: result.length, states: [...new Set(result.map(r => r.stateCode))], details: result.map(r => ({ start: r.start, end: r.end, state: r.state, stateCode: r.stateCode })) });
+
   set(cacheKey, result, 1800);
   return result;
 }

--- a/logic.js
+++ b/logic.js
@@ -109,8 +109,8 @@ async function fetchLeaveDays(token) {
 
   for (const leave of leaveDays) {
     if (!leave.Start || !leave.End) continue;
-    // State 1 = pending, State 2 = cancelled, State 3 = approved
-    if (leave.State === 2) continue;
+    // State 1 = pending, State 2 = cancelled, State 3 = approved, State 6 = cancellation requested
+    if (leave.State === 2 || leave.State === 6) continue;
     const startStr = leave.Start.split('T')[0];
     const endStr   = leave.End.split('T')[0];
     const status   = leave.State === 3 ? 'leave' : 'leave-pending';
@@ -147,9 +147,9 @@ async function fetchVacationData(token) {
 
     if (entry.IsHoliday) {
       map[iso] = 'holiday';
-    } else if (entry.DayType === 1 && entry.State !== 2) {
+    } else if (entry.DayType === 1 && entry.State !== 2 && entry.State !== 6) {
       // Vacation: State 3 = approved, State 1 = pending/requested
-      // State 2 = cancelled (skip — treat as regular workday)
+      // State 2 = cancelled, State 6 = cancellation requested (skip — treat as regular workday)
       if (!map[iso] || map[iso] !== 'holiday') {
         map[iso] = entry.State === 3 ? 'vacation' : 'vacation-pending';
       }
@@ -234,14 +234,12 @@ export async function getVacationRequestsList(credentials) {
 
   const result = ranges.map(r => ({
     type: 'Vacaciones',
-    state: r.state === 3 ? 'Aprobada' : r.state === 2 ? 'Cancelada' : 'Solicitada',
+    state: r.state === 3 ? 'Aprobada' : r.state === 2 ? 'Cancelada' : r.state === 6 ? 'Cancelación solicitada' : 'Solicitada',
     stateCode: r.state,
     start: r.start,
     end: r.end,
     year: r.year,
   }));
-
-  logInfo('Vacation ranges from API', { count: result.length, states: [...new Set(result.map(r => r.stateCode))], details: result.map(r => ({ start: r.start, end: r.end, state: r.state, stateCode: r.stateCode })) });
 
   set(cacheKey, result, 1800);
   return result;

--- a/public/css/panels.css
+++ b/public/css/panels.css
@@ -59,11 +59,13 @@ details.leave-days-panel[open] .card-header__chevron {
   border-left: 3px solid transparent;
 }
 
-.leave-day-item--approved          { border-left-color: #22c55e; }
-.leave-day-item--pending           { border-left-color: #f59e0b; }
-.leave-day-item--vacation-approved { border-left-color: #0284c7; }
-.leave-day-item--vacation-pending  { border-left-color: #0284c7; border-left-style: dashed; }
-.leave-day-item--past              { border-left-color: #94a3b8; opacity: 0.7; }
+.leave-day-item--approved           { border-left-color: #22c55e; }
+.leave-day-item--pending            { border-left-color: #f59e0b; }
+.leave-day-item--cancelled          { border-left-color: #ef4444; opacity: 0.65; }
+.leave-day-item--vacation-approved  { border-left-color: #0284c7; }
+.leave-day-item--vacation-pending   { border-left-color: #0284c7; border-left-style: dashed; }
+.leave-day-item--vacation-cancelled { border-left-color: #ef4444; border-left-style: dashed; opacity: 0.65; }
+.leave-day-item--past               { border-left-color: #94a3b8; opacity: 0.7; }
 
 .leave-day-icon {
   font-size: 1rem;
@@ -74,8 +76,10 @@ details.leave-days-panel[open] .card-header__chevron {
 
 .leave-day-item--approved .leave-day-icon          { color: #22c55e; }
 .leave-day-item--pending  .leave-day-icon           { color: #f59e0b; }
+.leave-day-item--cancelled .leave-day-icon           { color: #ef4444; }
 .leave-day-item--vacation-approved .leave-day-icon  { color: #0284c7; }
 .leave-day-item--vacation-pending  .leave-day-icon  { color: #0ea5e9; }
+.leave-day-item--vacation-cancelled .leave-day-icon { color: #ef4444; }
 .leave-day-item--past     .leave-day-icon           { color: #94a3b8; }
 
 .leave-day-info {

--- a/public/css/panels.css
+++ b/public/css/panels.css
@@ -59,13 +59,15 @@ details.leave-days-panel[open] .card-header__chevron {
   border-left: 3px solid transparent;
 }
 
-.leave-day-item--approved           { border-left-color: #22c55e; }
-.leave-day-item--pending            { border-left-color: #f59e0b; }
-.leave-day-item--cancelled          { border-left-color: #ef4444; opacity: 0.65; }
-.leave-day-item--vacation-approved  { border-left-color: #0284c7; }
-.leave-day-item--vacation-pending   { border-left-color: #0284c7; border-left-style: dashed; }
-.leave-day-item--vacation-cancelled { border-left-color: #ef4444; border-left-style: dashed; opacity: 0.65; }
-.leave-day-item--past               { border-left-color: #94a3b8; opacity: 0.7; }
+.leave-day-item--approved            { border-left-color: #22c55e; }
+.leave-day-item--pending             { border-left-color: #f59e0b; }
+.leave-day-item--cancelled           { border-left-color: #ef4444; opacity: 0.65; }
+.leave-day-item--cancelling          { border-left-color: #ef4444; border-left-style: dashed; opacity: 0.65; }
+.leave-day-item--vacation-approved   { border-left-color: #0284c7; }
+.leave-day-item--vacation-pending    { border-left-color: #0284c7; border-left-style: dashed; }
+.leave-day-item--vacation-cancelled  { border-left-color: #ef4444; border-left-style: dashed; opacity: 0.65; }
+.leave-day-item--vacation-cancelling { border-left-color: #ef4444; border-left-style: dashed; opacity: 0.65; }
+.leave-day-item--past                { border-left-color: #94a3b8; opacity: 0.7; }
 
 .leave-day-icon {
   font-size: 1rem;
@@ -74,13 +76,15 @@ details.leave-days-panel[open] .card-header__chevron {
   flex-shrink: 0;
 }
 
-.leave-day-item--approved .leave-day-icon          { color: #22c55e; }
-.leave-day-item--pending  .leave-day-icon           { color: #f59e0b; }
+.leave-day-item--approved .leave-day-icon           { color: #22c55e; }
+.leave-day-item--pending  .leave-day-icon            { color: #f59e0b; }
 .leave-day-item--cancelled .leave-day-icon           { color: #ef4444; }
-.leave-day-item--vacation-approved .leave-day-icon  { color: #0284c7; }
-.leave-day-item--vacation-pending  .leave-day-icon  { color: #0ea5e9; }
-.leave-day-item--vacation-cancelled .leave-day-icon { color: #ef4444; }
-.leave-day-item--past     .leave-day-icon           { color: #94a3b8; }
+.leave-day-item--cancelling .leave-day-icon          { color: #ef4444; }
+.leave-day-item--vacation-approved .leave-day-icon   { color: #0284c7; }
+.leave-day-item--vacation-pending  .leave-day-icon   { color: #0ea5e9; }
+.leave-day-item--vacation-cancelled .leave-day-icon  { color: #ef4444; }
+.leave-day-item--vacation-cancelling .leave-day-icon { color: #ef4444; }
+.leave-day-item--past     .leave-day-icon            { color: #94a3b8; }
 
 .leave-day-info {
   display: flex;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -391,9 +391,9 @@
       </summary>
       <div class="leave-days-list">
         <% upcomingVacation.forEach(function(v) { %>
-        <div class="leave-day-item leave-day-item--<%= v.stateCode === 3 ? 'vacation-approved' : (v.stateCode === 2 ? 'vacation-cancelled' : 'vacation-pending') %>">
+        <div class="leave-day-item leave-day-item--<%= v.stateCode === 3 ? 'vacation-approved' : (v.stateCode === 2 ? 'vacation-cancelled' : (v.stateCode === 6 ? 'vacation-cancelling' : 'vacation-pending')) %>">
           <div class="leave-day-icon">
-            <i class="fas fa-<%= v.stateCode === 3 ? 'plane' : (v.stateCode === 2 ? 'ban' : 'hourglass-half') %>"></i>
+            <i class="fas fa-<%= v.stateCode === 3 ? 'plane' : (v.stateCode === 2 ? 'ban' : (v.stateCode === 6 ? 'times-circle' : 'hourglass-half')) %>"></i>
           </div>
           <div class="leave-day-info">
             <span class="leave-day-type"><%= v.type %></span>
@@ -405,9 +405,9 @@
         </div>
         <% }); %>
         <% upcomingLeave.forEach(function(l) { %>
-        <div class="leave-day-item leave-day-item--<%= l.stateCode === 3 ? 'approved' : (l.stateCode === 2 ? 'cancelled' : 'pending') %>">
+        <div class="leave-day-item leave-day-item--<%= l.stateCode === 3 ? 'approved' : (l.stateCode === 2 ? 'cancelled' : (l.stateCode === 6 ? 'cancelling' : 'pending')) %>">
           <div class="leave-day-icon">
-            <i class="fas fa-<%= l.stateCode === 3 ? 'check-circle' : (l.stateCode === 2 ? 'ban' : 'clock') %>"></i>
+            <i class="fas fa-<%= l.stateCode === 3 ? 'check-circle' : (l.stateCode === 2 ? 'ban' : (l.stateCode === 6 ? 'times-circle' : 'clock')) %>"></i>
           </div>
           <div class="leave-day-info">
             <span class="leave-day-type"><%= l.type %></span>
@@ -422,8 +422,8 @@
         <details class="leave-days-past">
           <summary>Ver <%= pastVacation.length + pastLeave.length %> registro<%= (pastVacation.length + pastLeave.length) !== 1 ? 's' : '' %> pasado<%= (pastVacation.length + pastLeave.length) !== 1 ? 's' : '' %></summary>
           <% pastVacation.forEach(function(v) { %>
-          <div class="leave-day-item leave-day-item--<%= v.stateCode === 2 ? 'vacation-cancelled' : 'past' %>">
-            <div class="leave-day-icon"><i class="fas fa-<%= v.stateCode === 2 ? 'ban' : 'plane' %>"></i></div>
+          <div class="leave-day-item leave-day-item--<%= v.stateCode === 2 ? 'vacation-cancelled' : (v.stateCode === 6 ? 'vacation-cancelling' : 'past') %>">
+            <div class="leave-day-icon"><i class="fas fa-<%= v.stateCode === 2 ? 'ban' : (v.stateCode === 6 ? 'times-circle' : 'plane') %>"></i></div>
             <div class="leave-day-info">
               <span class="leave-day-type"><%= v.type %></span>
               <span class="leave-day-dates">
@@ -435,8 +435,8 @@
           <% }); %>
 
           <% pastLeave.forEach(function(l) { %>
-          <div class="leave-day-item leave-day-item--<%= l.stateCode === 2 ? 'cancelled' : 'past' %>">
-            <div class="leave-day-icon"><i class="fas fa-<%= l.stateCode === 2 ? 'ban' : 'history' %>"></i></div>
+          <div class="leave-day-item leave-day-item--<%= l.stateCode === 2 ? 'cancelled' : (l.stateCode === 6 ? 'cancelling' : 'past') %>">
+            <div class="leave-day-icon"><i class="fas fa-<%= l.stateCode === 2 ? 'ban' : (l.stateCode === 6 ? 'times-circle' : 'history') %>"></i></div>
             <div class="leave-day-info">
               <span class="leave-day-type"><%= l.type %></span>
               <span class="leave-day-dates">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -391,9 +391,9 @@
       </summary>
       <div class="leave-days-list">
         <% upcomingVacation.forEach(function(v) { %>
-        <div class="leave-day-item leave-day-item--<%= v.stateCode === 3 ? 'vacation-approved' : 'vacation-pending' %>">
+        <div class="leave-day-item leave-day-item--<%= v.stateCode === 3 ? 'vacation-approved' : (v.stateCode === 2 ? 'vacation-cancelled' : 'vacation-pending') %>">
           <div class="leave-day-icon">
-            <i class="fas fa-<%= v.stateCode === 3 ? 'plane' : 'hourglass-half' %>"></i>
+            <i class="fas fa-<%= v.stateCode === 3 ? 'plane' : (v.stateCode === 2 ? 'ban' : 'hourglass-half') %>"></i>
           </div>
           <div class="leave-day-info">
             <span class="leave-day-type"><%= v.type %></span>
@@ -405,9 +405,9 @@
         </div>
         <% }); %>
         <% upcomingLeave.forEach(function(l) { %>
-        <div class="leave-day-item leave-day-item--<%= l.stateCode === 3 ? 'approved' : 'pending' %>">
+        <div class="leave-day-item leave-day-item--<%= l.stateCode === 3 ? 'approved' : (l.stateCode === 2 ? 'cancelled' : 'pending') %>">
           <div class="leave-day-icon">
-            <i class="fas fa-<%= l.stateCode === 3 ? 'check-circle' : 'clock' %>"></i>
+            <i class="fas fa-<%= l.stateCode === 3 ? 'check-circle' : (l.stateCode === 2 ? 'ban' : 'clock') %>"></i>
           </div>
           <div class="leave-day-info">
             <span class="leave-day-type"><%= l.type %></span>
@@ -422,8 +422,8 @@
         <details class="leave-days-past">
           <summary>Ver <%= pastVacation.length + pastLeave.length %> registro<%= (pastVacation.length + pastLeave.length) !== 1 ? 's' : '' %> pasado<%= (pastVacation.length + pastLeave.length) !== 1 ? 's' : '' %></summary>
           <% pastVacation.forEach(function(v) { %>
-          <div class="leave-day-item leave-day-item--past">
-            <div class="leave-day-icon"><i class="fas fa-plane"></i></div>
+          <div class="leave-day-item leave-day-item--<%= v.stateCode === 2 ? 'vacation-cancelled' : 'past' %>">
+            <div class="leave-day-icon"><i class="fas fa-<%= v.stateCode === 2 ? 'ban' : 'plane' %>"></i></div>
             <div class="leave-day-info">
               <span class="leave-day-type"><%= v.type %></span>
               <span class="leave-day-dates">
@@ -433,9 +433,10 @@
             <span class="leave-day-state"><%= v.state %></span>
           </div>
           <% }); %>
+
           <% pastLeave.forEach(function(l) { %>
-          <div class="leave-day-item leave-day-item--past">
-            <div class="leave-day-icon"><i class="fas fa-history"></i></div>
+          <div class="leave-day-item leave-day-item--<%= l.stateCode === 2 ? 'cancelled' : 'past' %>">
+            <div class="leave-day-icon"><i class="fas fa-<%= l.stateCode === 2 ? 'ban' : 'history' %>"></i></div>
             <div class="leave-day-info">
               <span class="leave-day-type"><%= l.type %></span>
               <span class="leave-day-dates">


### PR DESCRIPTION
Cancelled vacation requests and leave days (State 2) were incorrectly shown as pending/solicitada in the leave panel and as vacation-pending on the calendar grid.

**Changes:**
- `logic.js`: skip State 2 from calendar map (cancelled days become regular workdays)
- `logic.js`: map State 2 to 'Cancelada' label in `getVacationRequestsList`
- `views/index.ejs`: show cancelled items with ban icon and cancelled CSS class
- `public/css/panels.css`: add red dashed border and reduced opacity for cancelled items